### PR TITLE
Fix supported minecraft versions compatibility table

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ See the [GitHub releases](https://github.com/Lucaslah/WeatherChanger/releases) p
 
 | Weather Changer Version | Minecraft Version | Mod loaders   | Latest Release                                                                     |
 |-------------------------|-------------------|---------------|------------------------------------------------------------------------------------|
-| v1.3.x                  | 1.21.11           | Fabric, Forge | [1.3.0-beta1](https://github.com/Lucaslah/WeatherChanger/releases/tag/1.3.0-beta1) |
-| v1.2.x                  | 1.21-1.21.10      | Fabric, Forge | [1.2.2](https://github.com/Lucaslah/WeatherChanger/releases/tag/1.2.2)             |
+| v1.3.x                  | 1.21.9-1.21.11    | Fabric, Forge | [1.3.0-beta1](https://github.com/Lucaslah/WeatherChanger/releases/tag/1.3.0-beta1) |
+| v1.2.x                  | 1.21-1.21.8       | Fabric, Forge | [1.2.2](https://github.com/Lucaslah/WeatherChanger/releases/tag/1.2.2)             |
 
 ------------------------------------------
 *Licensed under the [GNU Lesser General Public License v3.0](https://www.gnu.org/licenses/lgpl-3.0.en.html) license.*


### PR DESCRIPTION
v1.2.x was mislabeled as supported 1.21.9 and 1.21.10, v.1.3.x supports these versions.